### PR TITLE
Do not include .babelrc in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 *test.js
 /test/
 bench.js
+.babelrc


### PR DESCRIPTION
This is needed in addition to https://github.com/NickCis/polygonize/pull/1 in order to make this package work properly in React Native. Without this, `.babelrc` is included in the npm package which causes the React Native preprocessor to attempt to find the es2015 babel preset.